### PR TITLE
Use github actions for building and publishing

### DIFF
--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -12,12 +12,14 @@ jobs:
       with:
         repository: redis/redis
         path: redis
-    - name: Setup Snapcraft
-      run: |
-          sudo snap install snapcraft --classic
-          echo "$SNAP_TOKEN" | snapcraft login --with -
-          snapcraft
-          snapcraft upload --release=edge *.snap
+    - name: Build snap
+      uses: snapcore/action-build@v1
+      id: build
+    - name: Publish Snap
+      uses: snapcore/action-publish@v1
+      with:
+        store_login: ${{ secrets.SNAP_TOKEN }}
+        snap: ${{ steps.build.outputs.snap }}
+        release: edge
       env:
-        SNAP_TOKEN: ${{secrets.SNAP_TOKEN}}
         SNAPCRAFT_BUILD_ENVIRONMENT: host


### PR DESCRIPTION
Looks good so far, I just moved building and uploading the snap to the official GitHub actions [snapcore/action-build](https://github.com/snapcore/action-build) and [snapcore/action-publish](https://github.com/snapcore/action-publish)
This does not really change anything, but why replicate that functionality right?
Besides that your approach of pulling once a day sounds like a good solution to me. Thanks for the work 🙏🏻