### PR TITLE
Allow to read /etc/redis/redis.conf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,12 @@ grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 base: core20
 
+plugs:
+  etc-redis-redis-conf:
+    interface: system-files
+    read:
+    - /etc/redis/redis.conf
+
 apps:
   server:
     command: usr/bin/redis-server
@@ -22,6 +28,7 @@ apps:
       - network-bind
       - network-observe
       - home
+      - etc-redis-redis-conf
   cli:
     command: usr/bin/redis-cli
     plugs:
@@ -29,6 +36,7 @@ apps:
       - network-bind
       - network-observe
       - home
+      - etc-redis-redis-conf
   benchmark:
     command: usr/bin/redis-benchmark
     plugs:
@@ -36,6 +44,7 @@ apps:
       - network-bind
       - network-observe
       - home
+      - etc-redis-redis-conf
   check-aof:
     command: usr/bin/redis-check-aof
     plugs:
@@ -43,6 +52,7 @@ apps:
       - network-bind
       - network-observe
       - home
+      - etc-redis-redis-conf
   check-rdb:
     command: usr/bin/redis-check-rdb
     plugs:
@@ -50,6 +60,7 @@ apps:
       - network-bind
       - network-observe
       - home
+      - etc-redis-redis-conf
   sentinel:
     command: usr/bin/redis-sentinel
     plugs:
@@ -57,6 +68,7 @@ apps:
       - network-bind
       - network-observe
       - home
+      - etc-redis-redis-conf
 
 parts:
   redis:


### PR DESCRIPTION
Makes readable `/etc/redis/redis.conf` and allows to configure redis snap with it.

Additional systemd modifications requred:
1. Run `systemctl edit snap.redis.server`
2. Add following code to provide config path to redis executable (empty ExecStart required)
```
[Service]
ExecStart=
ExecStart=/usr/bin/snap run redis.server /etc/redis/redis.conf
```