### PR TITLE
add build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,10 @@
 <p align="center"><b>This is the snap for Redis</b>, <i>“Redis is used as a database, cache and message broker”</i>. It works on Ubuntu, Fedora, Debian, and other major Linux
 distributions.</p>
 
-<!-- Uncomment and modify this when you are provided a build status badge
-<p align="center">
-<a href="https://build.snapcraft.io/user/snapcrafters/fork-and-rename-me"><img src="https://build.snapcraft.io/badge/snapcrafters/fork-and-rename-me.svg" alt="Snap Status"></a>
-</p>
--->
-
-<!-- Uncomment and modify this when you have a screenshot
-![my-snap-name](screenshot.png?raw=true "my-snap-name")
--->
-
 <p align="center">Published for <img src="https://raw.githubusercontent.com/anythingcodes/slack-emoji-for-techies/gh-pages/emoji/tux.png" align="top" width="24" /> with 💝 by Snapcrafters</p>
+
+![tags](https://github.com/redis/redis-snap/actions/workflows/tags.yml/badge.svg)
+![unstable](https://github.com/redis/redis-snap/actions/workflows/unstable.yml/badge.svg)
 
 ## Install
 


### PR DESCRIPTION
This is a fix to add the badge provided by GitHub Actions to the README.