### PR TITLE
Add build info files into snap package

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
           sudo snap install snapcraft --classic
           echo "$SNAP_TOKEN" | snapcraft login --with -
-          snapcraft
+          SNAPCRAFT_BUILD_INFO=1 snapcraft
           snapcraft upload --release=stable *.snap
       env:
         SNAP_TOKEN: ${{secrets.SNAP_TOKEN}}

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -32,11 +32,11 @@ jobs:
     - name: Build amd64
       env:
         SNAPCRAFT_BUILD_ENVIRONMENT: host
-      run: snapcraft --target-arch amd64 --destructive-mode --enable-experimental-target-arch
+      run: SNAPCRAFT_BUILD_INFO=1 snapcraft --target-arch amd64 --destructive-mode --enable-experimental-target-arch
     - name: Build arm64
       env:
         SNAPCRAFT_BUILD_ENVIRONMENT: host
-      run: snapcraft --target-arch arm64 --destructive-mode --enable-experimental-target-arch
+      run: SNAPCRAFT_BUILD_INFO=1 snapcraft --target-arch arm64 --destructive-mode --enable-experimental-target-arch
     - name: Upload
       run: |
           for f in *.snap; do snapcraft upload --release=edge $f; done


### PR DESCRIPTION
## Issue

Redis snap package is not being scanned for security issues on snapcraft.io

**Motivation**

My organization plan to use a snap based OCI redis image for cloud deployments, which will require build info files for security scans.

**Context**

snapcraft supports collecting build information to facilitate security scans (see reference [here](https://snapcraft.io/blog/introducing-developer-notifications-for-snap-security-updates)), in the form of two files under `snap` directory inside the package, i.e.:
```
└── snap
     ├── manifest.yaml
     └── snapcraft.yaml 
```

## Proposal

Prepend `SNAPCRAFT_BUILD_INFO=1` on snapcraft calls so build files are included in the snap package.

**Notice**: this will also allow security notifications to be generated to the snap package owners, which is good, right ;) 