### PR TITLE
snap: add llvm and libclang-dev to build-packages for RediSearch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -76,7 +76,7 @@ parts:
     source: conf-dist
     organize:
       redis.conf: conf-dist/redis.conf
-  
+
   cmake-install:
     plugin: nil
     override-build: |
@@ -84,7 +84,7 @@ parts:
       snapcraftctl build
     build-packages:
       - snapd
-  
+
   redis:
     after: [cmake-install]
     plugin: make
@@ -117,6 +117,8 @@ parts:
       - unzip
       - rsync
       - clang
+      - llvm
+      - libclang-dev
       - automake
       - autoconf
       - libtool


### PR DESCRIPTION
This PR adds the following build packages to the redis part to fix RediSearch build failures due to missing libclang/llvm-config:

- llvm (provides llvm-config)
- libclang-dev (provides libclang.so)

The error seen in CI:
- clang-sys could not execute `llvm-config` and failed to find libclang shared libs.