### PR TITLE
Fix unstable not inheriting secrets when run in a schedule

### DIFF
--- a/.github/workflows/nightly-unstable-package.yaml
+++ b/.github/workflows/nightly-unstable-package.yaml
@@ -9,3 +9,4 @@ jobs:
   call-unstable-build:
     if: github.repository == 'redis/redis-snap'
     uses: redis/redis-snap/.github/workflows/unstable.yml@unstable
+    secrets: inherit


### PR DESCRIPTION
Unstable nightly should publish actual *edge* level release.