### PR TITLE
Use ubuntu-24.04-arm github runner label

### DIFF
--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -22,7 +22,7 @@ jobs:
           - architecture: amd64
             runner: ubuntu-24.04
           - architecture: arm64
-            runner: ubuntu24-arm64-4-16
+            runner: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.runner }}
 


### PR DESCRIPTION
Replace `ubuntu24-arm64-4-16` runner label with `ubuntu-24.04-arm`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the GitHub Actions runner label used for ARM64 builds, affecting CI execution environment but not product code.
> 
> **Overview**
> Updates the `build` job’s ARM64 GitHub Actions runner label in `build-n-test.yml`, replacing `ubuntu24-arm64-4-16` with `ubuntu-24.04-arm` to run builds on the new runner naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8117482ffff9b78c1c57916498c0678f21ab3cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->