### PR TITLE
Revert "Enable LTO for RediSearch module when Redis is build with modules"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,16 +13,6 @@ grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 base: core22
 
-# LLVM 21 (clang/lld/llvm-tools) is required to build RediSearch with LTO=1.
-# core22 ships clang 14, so pull a newer toolchain from the upstream LLVM apt
-# repository.
-package-repositories:
-  - type: apt
-    url: https://apt.llvm.org/jammy/
-    suites: [llvm-toolchain-jammy-21]
-    components: [main]
-    key-id: 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
-
 apps:
   server:
     command: >-
@@ -104,10 +94,7 @@ parts:
       - INSTALL_RUST_TOOLCHAIN: "yes"
       - DISABLE_WERRORS: "yes"
       - BUILD_TLS: "yes"
-      - LTO: "1"
     override-build: |
-      # Pick clang/lld/llvm-tools 21 for RediSearch's cross-language LTO link.
-      export PATH="/usr/lib/llvm-21/bin:$PATH"
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/lib/redis/modules
       make -j4
       PREFIX=${SNAPCRAFT_PART_INSTALL}/usr make install
@@ -136,7 +123,3 @@ parts:
       - curl
       - libssl-dev
       - jq
-      # LLVM 21 toolchain for RediSearch LTO (sourced from apt.llvm.org).
-      - clang-21
-      - lld-21
-      - llvm-21


### PR DESCRIPTION
Reverts redis/redis-snap#31

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the snap build toolchain and flags by removing the LLVM 21 dependency and disabling RediSearch LTO, which could affect build success and module performance/size.
> 
> **Overview**
> Reverts the previous RediSearch LTO enablement in `snap/snapcraft.yaml`.
> 
> This removes the custom LLVM 21 apt repository and related `clang-21`/`lld-21`/`llvm-21` build packages, drops the `LTO=1` build environment flag, and no longer prepends `/usr/lib/llvm-21/bin` to `PATH` during the Redis build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f8e5cfb546f3643dd1406ddd23b3d24d0130458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->