### PR TITLE
Install clang-21 for RediSearch LTO; exercise unstable in PRs

### DIFF
--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_tag == 'unstable' && env.UNSTABLE_BRANCH || '' }}
+          # Keep PR head on pull_request runs so the PR's snap/ is exercised.
+          ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && env.UNSTABLE_BRANCH || '' }}
 
       - name: Ensure Release Branch
         if: inputs.release_tag != '' && inputs.release_tag != 'unstable'
@@ -86,7 +87,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_tag == 'unstable' && env.UNSTABLE_BRANCH || '' }}
+          # See build job above.
+          ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && env.UNSTABLE_BRANCH || '' }}
 
       - name: Ensure Release Branch
         if: inputs.release_tag != '' && inputs.release_tag != 'unstable'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,10 +7,10 @@ on:
       - unstable
 
 jobs:
-  # TODO: we should have a way to run in unstable mode for PRs to unstable but
-  # without switching to unstable branch
   build-and-test:
     name: Build and Test
     uses: ./.github/workflows/build-n-test.yml
     with:
-      release_tag:
+      # PRs against unstable -> build redis/redis@unstable; otherwise use the
+      # stable pin in .redis_versions.json.
+      release_tag: ${{ github.base_ref == 'unstable' && 'unstable' || '' }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,15 @@ grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 base: core22
 
+# LLVM 21 (matches rustc 1.94's LLVM) is required to build RediSearch with LTO.
+# core22 ships clang 14, so pull the toolchain from apt.llvm.org.
+package-repositories:
+  - type: apt
+    url: https://apt.llvm.org/jammy/
+    suites: [llvm-toolchain-jammy-21]
+    components: [main]
+    key-id: 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
+
 apps:
   server:
     command: >-
@@ -95,6 +104,8 @@ parts:
       - DISABLE_WERRORS: "yes"
       - BUILD_TLS: "yes"
     override-build: |
+      # Prefer LLVM 21 toolchain on PATH for RediSearch's LTO link.
+      export PATH="/usr/lib/llvm-21/bin:$PATH"
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/lib/redis/modules
       make -j4
       PREFIX=${SNAPCRAFT_PART_INSTALL}/usr make install
@@ -123,3 +134,7 @@ parts:
       - curl
       - libssl-dev
       - jq
+      # LLVM 21 toolchain for RediSearch LTO (sourced from apt.llvm.org).
+      - clang-21
+      - lld-21
+      - llvm-21


### PR DESCRIPTION
The nightly unstable schedule was failing because redis/redis@unstable's modules/redisearch/Makefile now defaults LTO ?= 1, and RediSearch's cross-language LTO check aborts when clang resolves to v14 (core22's default) instead of v21 (matching rustc 1.94's LLVM).

snap/snapcraft.yaml: add an override-pull step that installs clang-21/lld-21/llvm-21 from apt.llvm.org, and prepend /usr/lib/llvm-21/bin to PATH in override-build.

.github/workflows/{pull-request,build-n-test}.yml: PRs against unstable now pass release_tag=unstable so they exercise the same redis/redis@unstable source as the nightly; the checkout-ref in build-n-test no longer overrides to UNSTABLE_BRANCH on pull_request events, so the PR's own snap/ packaging is what gets tested (mirrors the same fix already applied to redis-debian).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes affect snap build toolchain selection and GitHub Actions checkout/version selection, which can alter what code gets built and may impact release/CI behavior if the conditions are wrong.
> 
> **Overview**
> Fixes unstable snap builds by pulling the LLVM 21 toolchain from `apt.llvm.org`, adding `clang-21`/`lld-21`/`llvm-21` as build deps, and prepending `/usr/lib/llvm-21/bin` to `PATH` during the `snapcraft` `redis` part build so RediSearch LTO links with the expected clang.
> 
> Adjusts CI workflows so PRs targeting `unstable` pass `release_tag=unstable`, and the shared `build-n-test.yml` checkout no longer forces `UNSTABLE_BRANCH` on `pull_request` runs (ensuring the PR’s `snap/` changes are what get built/tested).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e3846ad56d6b0c5252c4cba8cf426d7526ad7e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->