### PR TITLE
RED-198334 Bump GH Actions off Node 20

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -16,7 +16,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Redis repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redis/redis
         path: redis
@@ -41,7 +41,7 @@ runs:
         sudo snap install snapcraft --classic
 
     - name: Setup LXD
-      uses: canonical/setup-lxd@v0.1.2
+      uses: canonical/setup-lxd@v1
 
     - name: Build Snap
       shell: bash
@@ -59,7 +59,7 @@ runs:
         echo "Built packages: $packages"
 
     - name: Upload to artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: redis-snap-${{ inputs.architecture }}-${{ github.sha }}
         path: '*.snap'
@@ -111,7 +111,7 @@ runs:
 
     - name: Upload build failure logs
       if: failure() && inputs.version == 'unstable'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-failure-${{ inputs.architecture }}-snap
         path: /tmp/build-logs/

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -29,14 +29,14 @@ runs:
 
     - name: Download artifact from current run
       if: inputs.run_id == ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: redis-snap-${{ inputs.architecture }}-${{ github.sha }}
         path: ./snap-artifacts
 
     - name: Download artifact from specific run
       if: inputs.run_id != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: redis-snap-${{ inputs.architecture }}-${{ github.sha }}
         path: ./snap-artifacts

--- a/.github/actions/update-redis-versions/action.yml
+++ b/.github/actions/update-redis-versions/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Create verified commit
       if: steps.update-versions.outputs.changed_files != ''
-      uses: iarekylew00t/verified-bot-commit@v1
+      uses: iarekylew00t/verified-bot-commit@v2
       with:
         message: "Update ${{ inputs.risk_level }} to ${{ inputs.release_tag }}"
         files: ${{ steps.update-versions.outputs.changed_files }}

--- a/.github/actions/upload/action.yml
+++ b/.github/actions/upload/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Download all artifacts from current run
       if: inputs.run_id == ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: redis-snap-*
         path: ./snap-artifacts
@@ -44,7 +44,7 @@ runs:
 
     - name: Download all artifacts from specific run
       if: inputs.run_id != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: redis-snap-*
         path: ./snap-artifacts

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Keep PR head on pull_request runs so the PR's snap/ is exercised.
           ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && env.UNSTABLE_BRANCH || '' }}
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # See build job above.
           ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && env.UNSTABLE_BRANCH || '' }}

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.release_tag == 'unstable' && 'unstable' || '' }}
 
@@ -83,7 +83,7 @@ jobs:
           RELEASE_HANDLE
 
       - name: Upload release handle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_handle
           path: result.json
@@ -97,7 +97,7 @@ jobs:
     if: failure()
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect env name
         id: detect-env

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate inputs
         id: validate-inputs
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload publish result artifact
         if: always() && steps.create-release-info.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_info
           path: result.json

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: >-
             ${{ (github.ref_name == 'unstable'


### PR DESCRIPTION
## Summary
RED-198334. Bump GitHub Actions still running on Node 20 ahead of the June 16, 2026 deprecation deadline.

- Bump `actions/checkout@v4` -> `@v6` (6 sites across `build/action.yml` + `build-n-test.yml` + `release_build_and_test.yml` + `release_publish.yml` + `unstable.yml`)
- Bump `actions/upload-artifact@v4` -> `@v7` (4 sites) and `actions/download-artifact@v4` -> `@v7` (4 sites across `run-tests` and `upload` composite actions)
- Bump `canonical/setup-lxd@v0.1.2` -> `@v1` (maintainer now publishes a rolling `@v1` tag, composite runtime)
- Bump `iarekylew00t/verified-bot-commit@v1` -> `@v2` in `update-redis-versions` composite action

## Test plan
- [ ] `build-n-test.yml` and `unstable.yml` build snap packages cleanly with `canonical/setup-lxd@v1`
- [ ] `release_build_and_test.yml` workflow_dispatch run produces a verified bot commit on the release branch
- [ ] `release_publish.yml` workflow_dispatch run uploads packages to the Snap Store cleanly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only updates to CI actions with no application or release logic changes; risk is limited to possible breaking behavior in newer action majors until workflows are re-run.
> 
> **Overview**
> Bumps GitHub Actions used in snap **build**, **test**, **upload**, and **release** workflows off **Node 20** ahead of GitHub’s deprecation deadline.
> 
> **`actions/checkout`** moves from **v4** to **v6** everywhere the repo checks out code (composite build action and build/test/publish/unstable workflows). **`actions/upload-artifact`** and **`actions/download-artifact`** move from **v4** to **v7** for snap artifacts, release handles, failure logs, and publish results. **`canonical/setup-lxd`** in the build composite action moves from **v0.1.2** to **v1**. **`iarekylew00t/verified-bot-commit`** in **`update-redis-versions`** moves from **v1** to **v2** for verified version-bump commits.
> 
> No workflow logic, inputs, or shell steps change—only action version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3062b209b9023d417128a26bea3bd8cefeb0a38c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->