### PR TITLE
RED-198334 Bump GH Actions off Node 20 (unstable)

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -16,7 +16,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Redis repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redis/redis
         path: redis
@@ -41,7 +41,7 @@ runs:
         sudo snap install snapcraft --classic
 
     - name: Setup LXD
-      uses: canonical/setup-lxd@v0.1.2
+      uses: canonical/setup-lxd@v1
 
     - name: Build Snap
       shell: bash
@@ -59,7 +59,7 @@ runs:
         echo "Built packages: $packages"
 
     - name: Upload to artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: redis-snap-${{ inputs.architecture }}-${{ github.sha }}
         path: '*.snap'
@@ -111,7 +111,7 @@ runs:
 
     - name: Upload build failure logs
       if: failure() && inputs.version == 'unstable'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-failure-${{ inputs.architecture }}-snap
         path: /tmp/build-logs/

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -29,14 +29,14 @@ runs:
 
     - name: Download artifact from current run
       if: inputs.run_id == ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: redis-snap-${{ inputs.architecture }}-${{ github.sha }}
         path: ./snap-artifacts
 
     - name: Download artifact from specific run
       if: inputs.run_id != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: redis-snap-${{ inputs.architecture }}-${{ github.sha }}
         path: ./snap-artifacts

--- a/.github/actions/update-redis-versions/action.yml
+++ b/.github/actions/update-redis-versions/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Create verified commit
       if: steps.update-versions.outputs.changed_files != ''
-      uses: iarekylew00t/verified-bot-commit@v1
+      uses: iarekylew00t/verified-bot-commit@v2
       with:
         message: "Update ${{ inputs.risk_level }} to ${{ inputs.release_tag }}"
         files: ${{ steps.update-versions.outputs.changed_files }}

--- a/.github/actions/upload/action.yml
+++ b/.github/actions/upload/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Download all artifacts from current run
       if: inputs.run_id == ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: redis-snap-*
         path: ./snap-artifacts
@@ -44,7 +44,7 @@ runs:
 
     - name: Download all artifacts from specific run
       if: inputs.run_id != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: redis-snap-*
         path: ./snap-artifacts

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Keep PR head on pull_request runs so the PR's snap/ is exercised.
           ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && env.UNSTABLE_BRANCH || '' }}
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # See build job above.
           ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && env.UNSTABLE_BRANCH || '' }}

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.release_tag == 'unstable' && 'unstable' || '' }}
 
@@ -83,7 +83,7 @@ jobs:
           RELEASE_HANDLE
 
       - name: Upload release handle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_handle
           path: result.json
@@ -97,7 +97,7 @@ jobs:
     if: failure()
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect env name
         id: detect-env

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate inputs
         id: validate-inputs
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload publish result artifact
         if: always() && steps.create-release-info.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_info
           path: result.json

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: >-
             ${{ (github.ref_name == 'unstable'


### PR DESCRIPTION
## Summary
RED-198334 on `unstable`. Cherry-pick of the master fix ([#36](https://github.com/redis/redis-snap/pull/36)). The `unstable` branch mirrors `master`'s file/composite structure, so a clean CP applies without conflicts.

- Bump `actions/checkout@v4` -> `@v6` (6 sites across `build/action.yml` + `build-n-test.yml` + `release_build_and_test.yml` + `release_publish.yml` + `unstable.yml`)
- Bump `actions/upload-artifact@v4` -> `@v7` (4 sites) and `actions/download-artifact@v4` -> `@v7` (4 sites across `run-tests` and `upload` composite actions)
- Bump `canonical/setup-lxd@v0.1.2` -> `@v1`
- Bump `iarekylew00t/verified-bot-commit@v1` -> `@v2`

## Test plan
- [ ] `build-n-test.yml` and `unstable.yml` build snap packages cleanly with `canonical/setup-lxd@v1`
- [ ] Nightly unstable schedule still produces packages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only CI dependency updates with no application or snap packaging logic changes; main risk is regression if a new action major breaks inputs or artifact behavior.
> 
> **Overview**
> Bumps third-party GitHub Actions across snap **build**, **test**, **upload**, and **release** automation so workflows run on newer action runtimes (off Node 20), without changing build or publish behavior.
> 
> **Checkout** moves from `actions/checkout@v4` to `@v6` in the build composite (Redis repo checkout) and in `build-n-test`, `release_build_and_test`, `release_publish`, and `unstable` workflows. **Artifacts** move from `upload-artifact` / `download-artifact` `@v4` to `@v7` in build (snap + failure logs), `run-tests`, `upload`, and release workflows. **Snap build** uses `canonical/setup-lxd@v1` instead of `@v0.1.2`. **Version bumps** on release branches use `iarekylew00t/verified-bot-commit@v2` instead of `@v1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d1caf97f572685b11a76b3b6cc9e0086c64a7d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->