### PR TITLE
Adapt to the new upstream modules build system

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -16,7 +16,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Redis repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redis/redis
         path: redis
@@ -41,7 +41,7 @@ runs:
         sudo snap install snapcraft --classic
 
     - name: Setup LXD
-      uses: canonical/setup-lxd@v0.1.2
+      uses: canonical/setup-lxd@v1
 
     - name: Build Snap
       shell: bash
@@ -59,7 +59,7 @@ runs:
         echo "Built packages: $packages"
 
     - name: Upload to artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: redis-snap-${{ inputs.architecture }}-${{ github.sha }}
         path: '*.snap'
@@ -111,7 +111,7 @@ runs:
 
     - name: Upload build failure logs
       if: failure() && inputs.version == 'unstable'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-failure-${{ inputs.architecture }}-snap
         path: /tmp/build-logs/

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -26,14 +26,12 @@ runs:
       if: inputs.version == 'unstable'
       shell: bash
       run: |
-        echo "Updating module versions to use master branch"
-        for module in redisbloom redisearch redistimeseries redisjson; do
-          if [ -f "redis/modules/${module}/Makefile" ]; then
-            echo "Updating ${module} to use master branch"
-            sed -i 's/MODULE_VERSION = .*/MODULE_VERSION = master/' "redis/modules/${module}/Makefile"
-            echo "Verifying ${module} version: $(grep "MODULE_VERSION" "redis/modules/${module}/Makefile")"
-          fi
-        done
+        echo "Updating module refs to use master branch"
+        if ! command -v yq >/dev/null 2>&1; then
+          sudo snap install yq
+        fi
+        yq -i '.modules[].ref = "master"' redis/modules/modules.yaml
+        yq '.modules[] | .name + "=" + .ref' redis/modules/modules.yaml
 
     - name: Setup Snapcraft
       shell: bash
@@ -89,7 +87,10 @@ runs:
         # Get Redis source info
         if [ -d "redis" ]; then
           (cd redis && git log -n 3) > /tmp/build-logs/redis-git-info.log 2>&1
-          find redis/modules -name "Makefile" -exec grep "MODULE_VERSION" {} \; > /tmp/build-logs/module-versions.log 2>&1
+          if [ -f redis/modules/modules.yaml ]; then
+            yq '.modules[] | .name + "=" + .ref' redis/modules/modules.yaml > /tmp/build-logs/module-refs.log 2>&1 || \
+              cp redis/modules/modules.yaml /tmp/build-logs/modules.yaml
+          fi
         fi
 
         # Get snap parts info if they exist

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -29,14 +29,14 @@ runs:
 
     - name: Download artifact from current run
       if: inputs.run_id == ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: redis-snap-${{ inputs.architecture }}-${{ github.sha }}
         path: ./snap-artifacts
 
     - name: Download artifact from specific run
       if: inputs.run_id != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: redis-snap-${{ inputs.architecture }}-${{ github.sha }}
         path: ./snap-artifacts

--- a/.github/actions/update-redis-versions/action.yml
+++ b/.github/actions/update-redis-versions/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Create verified commit
       if: steps.update-versions.outputs.changed_files != ''
-      uses: iarekylew00t/verified-bot-commit@v1
+      uses: iarekylew00t/verified-bot-commit@v2
       with:
         message: "Update ${{ inputs.risk_level }} to ${{ inputs.release_tag }}"
         files: ${{ steps.update-versions.outputs.changed_files }}

--- a/.github/actions/upload/action.yml
+++ b/.github/actions/upload/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Download all artifacts from current run
       if: inputs.run_id == ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: redis-snap-*
         path: ./snap-artifacts
@@ -44,7 +44,7 @@ runs:
 
     - name: Download all artifacts from specific run
       if: inputs.run_id != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: redis-snap-*
         path: ./snap-artifacts

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Keep PR head on pull_request runs so the PR's snap/ is exercised.
           ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && env.UNSTABLE_BRANCH || '' }}
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # See build job above.
           ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && env.UNSTABLE_BRANCH || '' }}

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.release_tag == 'unstable' && 'unstable' || '' }}
 
@@ -83,7 +83,7 @@ jobs:
           RELEASE_HANDLE
 
       - name: Upload release handle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_handle
           path: result.json
@@ -97,7 +97,7 @@ jobs:
     if: failure()
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect env name
         id: detect-env

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate inputs
         id: validate-inputs
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload publish result artifact
         if: always() && steps.create-release-info.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_info
           path: result.json

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: >-
             ${{ (github.ref_name == 'unstable'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,16 +99,13 @@ parts:
     plugin: make
     source: redis
     build-environment:
-      - BUILD_WITH_MODULES: "yes"
-      - INSTALL_RUST_TOOLCHAIN: "yes"
-      - DISABLE_WERRORS: "yes"
       - BUILD_TLS: "yes"
     override-build: |
       # Prefer LLVM 21 toolchain on PATH for RediSearch's LTO link.
       export PATH="/usr/lib/llvm-21/bin:$PATH"
-      mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/lib/redis/modules
-      make -j4
-      PREFIX=${SNAPCRAFT_PART_INSTALL}/usr make install
+      make modules-update MODULES_UPDATE_SHALLOW=1
+      make -C modules install-rust INSTALL_RUST_TOOLCHAIN=yes
+      make -j4 deploy PREFIX=${SNAPCRAFT_PART_INSTALL}/usr
       VER=`sed -n 's/^.* REDIS_VERSION "\(.*\)"$/\1/g p' < src/version.h`
       if [ "$VER" = "255.255.255" ]; then
           GITSHA=`sed -n 's/^.* REDIS_GIT_SHA1 "\(.*\)"$/\1/g p' < src/release.h`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the snap packaging path for Redis and bundled modules (release-critical), though behavior is intended to match upstream; CI action major-version bumps can surface workflow compatibility issues.
> 
> **Overview**
> Aligns the Redis snap build and unstable CI with Redis’s **new centralized modules workflow** (`modules.yaml` + `make modules-update` / `deploy`) instead of per-module Makefile `MODULE_VERSION` edits and the old `BUILD_WITH_MODULES` snap build path.
> 
> In **`snap/snapcraft.yaml`**, the redis part now runs `make modules-update MODULES_UPDATE_SHALLOW=1`, `make -C modules install-rust INSTALL_RUST_TOOLCHAIN=yes`, and `make -j4 deploy PREFIX=…`, dropping the previous direct `make` / `make install` and related build-environment flags.
> 
> For **unstable builds**, `.github/actions/build` sets every module `ref` to `master` via **`yq` on `redis/modules/modules.yaml`**, and failure log capture records module refs from that file rather than Makefile grep output.
> 
> **GitHub Actions** are bumped repo-wide: `actions/checkout@v6`, `actions/upload-artifact@v7` / `download-artifact@v7`, `canonical/setup-lxd@v1`, and `verified-bot-commit@v2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a5e26b78039441f5053e1c07d295f4c16ac723f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->