### PR TITLE
Adapt to the new redis modules build system

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -26,14 +26,12 @@ runs:
       if: inputs.version == 'unstable'
       shell: bash
       run: |
-        echo "Updating module versions to use master branch"
-        for module in redisbloom redisearch redistimeseries redisjson; do
-          if [ -f "redis/modules/${module}/Makefile" ]; then
-            echo "Updating ${module} to use master branch"
-            sed -i 's/MODULE_VERSION = .*/MODULE_VERSION = master/' "redis/modules/${module}/Makefile"
-            echo "Verifying ${module} version: $(grep "MODULE_VERSION" "redis/modules/${module}/Makefile")"
-          fi
-        done
+        echo "Updating module refs to use master branch"
+        if ! command -v yq >/dev/null 2>&1; then
+          sudo snap install yq
+        fi
+        yq -i '.modules[].ref = "master"' redis/modules/modules.yaml
+        yq '.modules[] | .name + "=" + .ref' redis/modules/modules.yaml
 
     - name: Setup Snapcraft
       shell: bash
@@ -89,7 +87,10 @@ runs:
         # Get Redis source info
         if [ -d "redis" ]; then
           (cd redis && git log -n 3) > /tmp/build-logs/redis-git-info.log 2>&1
-          find redis/modules -name "Makefile" -exec grep "MODULE_VERSION" {} \; > /tmp/build-logs/module-versions.log 2>&1
+          if [ -f redis/modules/modules.yaml ]; then
+            yq '.modules[] | .name + "=" + .ref' redis/modules/modules.yaml > /tmp/build-logs/module-refs.log 2>&1 || \
+              cp redis/modules/modules.yaml /tmp/build-logs/modules.yaml
+          fi
         fi
 
         # Get snap parts info if they exist

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,16 +99,13 @@ parts:
     plugin: make
     source: redis
     build-environment:
-      - BUILD_WITH_MODULES: "yes"
-      - INSTALL_RUST_TOOLCHAIN: "yes"
-      - DISABLE_WERRORS: "yes"
       - BUILD_TLS: "yes"
     override-build: |
       # Prefer LLVM 21 toolchain on PATH for RediSearch's LTO link.
       export PATH="/usr/lib/llvm-21/bin:$PATH"
-      mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/lib/redis/modules
-      make -j4
-      PREFIX=${SNAPCRAFT_PART_INSTALL}/usr make install
+      make modules-update MODULES_UPDATE_SHALLOW=1
+      make -C modules install-rust INSTALL_RUST_TOOLCHAIN=yes
+      make -j4 deploy PREFIX=${SNAPCRAFT_PART_INSTALL}/usr
       VER=`sed -n 's/^.* REDIS_VERSION "\(.*\)"$/\1/g p' < src/version.h`
       if [ "$VER" = "255.255.255" ]; then
           GITSHA=`sed -n 's/^.* REDIS_GIT_SHA1 "\(.*\)"$/\1/g p' < src/release.h`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the snap’s module fetch/build/install path; release builds depend on upstream `modules-update`, Rust install, and `deploy` targets behaving as expected.
> 
> **Overview**
> Aligns snap packaging and unstable CI with Redis’s centralized module build, driven by `modules/modules.yaml` and top-level `make` targets instead of per-module `Makefile` `MODULE_VERSION` edits.
> 
> For **unstable** builds, the composite action now installs `yq` and sets every module’s `ref` to `master` in `redis/modules/modules.yaml`, and failure logs record those refs (or the YAML file) instead of grepping `MODULE_VERSION` from module Makefiles.
> 
> The **redis** snap part drops the old `BUILD_WITH_MODULES` / `INSTALL_RUST_TOOLCHAIN` / `DISABLE_WERRORS` environment and replaces `make` + `make install` with `make modules-update MODULES_UPDATE_SHALLOW=1`, `make -C modules install-rust INSTALL_RUST_TOOLCHAIN=yes`, and `make deploy` into the snap prefix (LLVM 21 on `PATH` for RediSearch LTO is unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a5e26b78039441f5053e1c07d295f4c16ac723f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->