### PR TITLE
Support old module build system

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -103,9 +103,18 @@ parts:
     override-build: |
       # Prefer LLVM 21 toolchain on PATH for RediSearch's LTO link.
       export PATH="/usr/lib/llvm-21/bin:$PATH"
-      make modules-update MODULES_UPDATE_SHALLOW=1
-      make -C modules install-rust INSTALL_RUST_TOOLCHAIN=yes
-      make -j4 deploy PREFIX=${SNAPCRAFT_PART_INSTALL}/usr
+
+      if [ -f modules/modules.yaml ]; then
+        make modules-update MODULES_UPDATE_SHALLOW=1
+        make -C modules install-rust INSTALL_RUST_TOOLCHAIN=yes
+        make -j4 deploy PREFIX=${SNAPCRAFT_PART_INSTALL}/usr
+      else
+        export BUILD_WITH_MODULES=yes
+        export INSTALL_RUST_TOOLCHAIN=yes
+        mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/lib/redis/modules
+        make -j4
+        PREFIX=${SNAPCRAFT_PART_INSTALL}/usr make install
+      fi
       VER=`sed -n 's/^.* REDIS_VERSION "\(.*\)"$/\1/g p' < src/version.h`
       if [ "$VER" = "255.255.255" ]; then
           GITSHA=`sed -n 's/^.* REDIS_GIT_SHA1 "\(.*\)"$/\1/g p' < src/release.h`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Packaging-only change in snap build scripts; runtime Redis behavior is unchanged, with moderate risk only if the legacy make path is wrong for some Redis versions.
> 
> **Overview**
> Snap packaging for Redis no longer assumes the **`modules/modules.yaml`**-driven module workflow. The **`redis`** part **`override-build`** branches on whether that file exists in the source tree.
> 
> When **`modules/modules.yaml`** is present, behavior is unchanged: **`modules-update`**, Rust toolchain install under **`modules`**, and **`make deploy`** into the snap prefix. When it is missing (older Redis releases), the build sets **`BUILD_WITH_MODULES=yes`** and **`INSTALL_RUST_TOOLCHAIN=yes`**, creates the modules install directory, runs a plain **`make -j4`**, then **`make install`** with **`PREFIX`** pointing at the snap staging area—matching the pre-yaml module build system.
> 
> LLVM 21 on **`PATH`** and version extraction via **`snapcraftctl set-version`** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71e08b2ca7fba04ea759840c1ee0508424f5616e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->